### PR TITLE
add missing mods block in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,12 @@ legacyForge {
                     .getAbsolutePath(), '--existing', file('src/main/resources/').getAbsolutePath())
         }
     }
+
+    mods {
+        "${mod_id}" {
+            sourceSet(sourceSets.main)
+        }
+    }
 }
 
 mixin {


### PR DESCRIPTION
as in title. this block is necessary for mods to run correctly in mdg. it now builds and runs correctly.